### PR TITLE
[feat/#71] BasicButton 컴포넌트 개발

### DIFF
--- a/src/components/BasicButton/BasicButton.module.scss
+++ b/src/components/BasicButton/BasicButton.module.scss
@@ -1,0 +1,74 @@
+@use 'src/styles/_color' as color;
+@use 'src/styles/_font' as font;
+@use 'src/styles/_media' as media;
+
+.default {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  border: none;
+  outline: none;
+  border-radius: 8px;
+  cursor: pointer;
+
+  @include font.Style(xl, 600);
+
+  @include media.desktop {
+    @include font.Style(xl, 600);
+  }
+
+  @include media.tablet {
+    @include font.Style(lg, 600);
+  }
+
+  @include media.mobile {
+    @include font.Style(lg, 600);
+  }
+}
+
+.icon {
+  width: 36px;
+  height: 36px;
+
+  @include media.tablet {
+    width: 24px;
+    height: 24px;
+  }
+
+  @include media.mobile {
+    width: 24px;
+    height: 24px;
+  }
+}
+
+.solid {
+  background-color: color.$Primary-Orange-300;
+  color: color.$Grayscale-50;
+
+  &:hover {
+    background-color: color.$Primary-Orange-200;
+  }
+
+  &:disabled {
+    background-color: color.$Grayscale-100;
+  }
+}
+
+.outline {
+  background-color: transparent;
+  border: 1px solid color.$Primary-Orange-300;
+  color: color.$Primary-Orange-300;
+
+  &:hover {
+    border: 1px solid color.$Primary-Orange-200;
+    color: color.$Primary-Orange-200;
+  }
+
+  &:disabled {
+    border: 1px solid color.$Grayscale-100;
+    color: color.$Grayscale-100;
+  }
+}

--- a/src/components/BasicButton/BasicButton.tsx
+++ b/src/components/BasicButton/BasicButton.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import style from '@/components/BasicButton/BasicButton.module.scss'
+import Image from 'next/image'
+import React from 'react'
+
+interface ButtonProps {
+  type: 'solid' | 'outline'
+  disable: boolean
+  onClick: () => void
+  children: React.ReactNode
+}
+
+interface IconProps {
+  src: string
+}
+
+interface TextProps {
+  children: React.ReactNode
+}
+
+const BaiscButton = ({ type, disable, onClick, children }: ButtonProps) => {
+  const buttonClass = `${style.default} ${style[type]}`
+
+  return (
+    <button className={buttonClass} disabled={disable} onClick={onClick}>
+      {children}
+    </button>
+  )
+}
+
+const ButtonIcon = ({ src }: IconProps) => {
+  return (
+    <Image src={src} alt="Icon" width={36} height={36} className={style.icon} />
+  )
+}
+
+const ButtonText = ({ children }: TextProps) => {
+  return <span>{children}</span>
+}
+
+BaiscButton.Icon = ButtonIcon
+BaiscButton.Text = ButtonText
+
+export default BaiscButton


### PR DESCRIPTION
resolved: #71

# 설명

# 베이직 버튼 쓰이는 곳 

1. 로그인하기
	로그인_지원자
	로그인_사장님
2. 회원가입 
	회원가입_지원자
	회원가입_사장님
	회원가입_지원자 정보  입력
	회원가입_사장님 정보  입력
3. 알바폼 자세히보기
	알바폼 상세_지원자
	알바폼 상세_사장님 
4. 알바폼 상세_모달
	알바폼 상세_지원자_모집마감 모달
	알바폼 상세_지원자_내 지원내역 모달 
	알바폼 상세_사장님_삭제 모달
	알바폼_지원자 상세_진행상태선택 모달 
5. 알바폼 작성하기
	알바폼 지원_지원자
6. 알바폼 만들기_모집내용 & 모집조건 & 근무조건 & 수정_사장님
7. 마이페이지
8. 알바토크_상세페이지 

# 버튼설명
데스크탑에선 fontsize는 전부 20, 태블릿 모바일 환경은 16입니다 -> 미디어쿼리 설정했습니다.
(단, 마이페이지 내정보 수정, 비밀번호 변경 부분만 데스크탑일때 18px로 되어있습니다. 해당부분만 박스사이징 조정해주시면 될 것같습니다 -> 태블릿과 모바일에서는 해당 버튼이 없기 때문입니다.)

아이콘역시 따로 width와 height 지정안해주셔도됩니다.  
 
# 사용법

버튼은 쓰이는 곳이 많아 width와 height 조정이 사용되는 곳에서 적절한 설정이 필요할것 같다고 생각해서,
width와 height는 100%로 지정하였습니다. 

경로는 'icons/ic-원하는 아이콘.svg' 로 입력해주셔합니다.(Next.js에서 public 폴더는 자동으로 프로젝트의 루트 디렉토리로 매핑됩니다. 따라서 이미지나 파일을 참조할 때는 /public을 경로에 포함하지않습니다.)