### PR TITLE
[feat/#250] 지원하기 관련 기능 수정

### DIFF
--- a/src/app/albatalks/page.module.scss
+++ b/src/app/albatalks/page.module.scss
@@ -118,7 +118,7 @@
   transition: transform 0.3s ease;
 
   &:hover {
-    transform: translateX(-50%) translateY(-15px);
+    transform: translateX(-50%) translateY(-8px);
   }
 }
 

--- a/src/app/applications/page.module.scss
+++ b/src/app/applications/page.module.scss
@@ -55,6 +55,6 @@
   transition: transform 0.3s ease;
 
   &:hover {
-    transform: translateX(-50%) translateY(-15px);
+    transform: translateX(-50%) translateY(-8px);
   }
 }

--- a/src/app/form/[formId]/application/[applicationId]/page.tsx
+++ b/src/app/form/[formId]/application/[applicationId]/page.tsx
@@ -10,15 +10,17 @@ import styles from '../page.module.scss'
 // 여긴 사장이 지원 상세 조회 / 상세 수정
 
 export default function ApplicationDetailsPage({ params }: Params) {
+  const { formId } = params
   const user = useUserStore.getState().user
   const router = useRouter()
 
   switch (user?.role) {
     case undefined:
       router.replace('/user/sign-in')
-      break
+      return null
     case 'APPLICANT':
-      router.back()
+      router.replace(`form/${formId}`)
+      return null
   }
 
   return (

--- a/src/app/form/[formId]/apply/page.module.scss
+++ b/src/app/form/[formId]/apply/page.module.scss
@@ -1,16 +1,24 @@
-@use 'src/styles/_media' as media;
+@use '@/styles/_variables' as var;
+@use '@/styles/_color' as color;
+@use '@/styles/_font' as font;
+@use '@/styles/_media' as media;
 
 .apply-form {
-  margin: 78px 320px;
+  margin: 0 auto;
+  padding: 72px 24px;
+  max-width: 640px;
+  height: calc(100vh - var.$root_header_height_lg);
+  overflow: auto;
 
   @include media.tablet {
-    margin: 0 184px 50px;
+    height: calc(100vh - var.$root_header_height_md);
+    padding: 48px 24px;
     row-gap: 32px;
   }
 
   @include media.mobile {
-    margin: 0;
-    margin-bottom: 50px;
+    height: calc(100vh - var.$root_header_height_sm);
+    padding: 24px;
   }
 }
 
@@ -19,26 +27,12 @@
   place-content: center space-between;
 }
 
-.cancel-button {
-  height: 50px;
-}
-
 .button-container {
   margin-top: 30px;
   display: flex;
   gap: 8px;
 
-  @include media.tablet {
-    flex-direction: column;
-  }
-
   @include media.mobile {
     flex-direction: column;
-  }
-}
-
-@media screen and (width >= 1024px) and (width <= 1500px) {
-  .apply-form {
-    margin: 78px 30px 0;
   }
 }

--- a/src/app/forms/page.module.scss
+++ b/src/app/forms/page.module.scss
@@ -77,7 +77,7 @@
   transition: transform 0.3s ease;
 
   &:hover {
-    transform: translateX(-50%) translateY(-15px);
+    transform: translateX(-50%) translateY(-8px);
   }
 }
 
@@ -88,8 +88,15 @@
 
 .make-your-form {
   position: fixed;
-  bottom: 32px;
-  left: 50%;
-  z-index: 2;
-  transform: translateX(-50%);
+  right: 80px;
+  bottom: 80px;
+  z-index: 16;
+
+  @include media.tablet {
+    right: 40px;
+  }
+
+  @include media.mobile {
+    right: 24px;
+  }
 }

--- a/src/app/ownersForms/page.module.scss
+++ b/src/app/ownersForms/page.module.scss
@@ -5,10 +5,17 @@
 
 .make-your-form {
   position: fixed;
-  bottom: 32px;
-  left: 50%;
-  z-index: 2;
-  transform: translateX(-50%);
+  right: 80px;
+  bottom: 80px;
+  z-index: 16;
+
+  @include media.tablet {
+    right: 40px;
+  }
+
+  @include media.mobile {
+    right: 24px;
+  }
 }
 
 .list-page {
@@ -90,6 +97,6 @@
   transition: transform 0.3s ease;
 
   &:hover {
-    transform: translateX(-50%) translateY(-15px);
+    transform: translateX(-50%) translateY(-8px);
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,7 +54,6 @@ const IMAGE_DESC = [
 
 export default function Home() {
   const { user } = useUserStore()
-  console.log('user: ', user)
 
   return (
     <main className={styles.main}>

--- a/src/app/user/me/page.module.scss
+++ b/src/app/user/me/page.module.scss
@@ -176,7 +176,7 @@
   transition: transform 0.3s ease;
 
   &:hover {
-    transform: translateX(-50%) translateY(-15px);
+    transform: translateX(-50%) translateY(-8px);
   }
 }
 

--- a/src/app/user/sign-in/page.tsx
+++ b/src/app/user/sign-in/page.tsx
@@ -16,14 +16,13 @@ import { getRandomInt } from '@/lib/utils/acountGenerator'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 import { FieldValues } from 'react-hook-form'
 
 export default function SignInPage() {
   const user = useUserStore.getState().user
   const router = useRouter()
   const signIn = useSignIn()
-
-  if (user) router.replace('/')
 
   async function handleSignIn({ email, password }: SignInValues) {
     await signIn.mutateAsync({ email, password })
@@ -41,8 +40,12 @@ export default function SignInPage() {
       email: user.email,
       password: user.password,
     })
-    handleSignIn({ email: user.email, password: user.password })
+    await handleSignIn({ email: user.email, password: user.password })
   }
+
+  useEffect(() => {
+    if (user) router.replace('/')
+  }, [user, router])
 
   return (
     <article className={signInSignUpStyles.container}>

--- a/src/components/FormDetails/CurrentApplicationPopup/CurrentApplicationPopup.tsx
+++ b/src/components/FormDetails/CurrentApplicationPopup/CurrentApplicationPopup.tsx
@@ -34,6 +34,8 @@ export default function CurrentApplicationPopup({
       false
     )
 
+  if (formDetails?.applyCount <= 0) return null
+
   return (
     <div
       className={`${styles['popup-container']} ${isClosing ? styles.closing : ''} ${
@@ -49,7 +51,7 @@ export default function CurrentApplicationPopup({
           className={styles['popup-image']}
         />
         <span className={styles['popup-current-application']}>
-          현재{' '}
+          현재&nbsp;
           <span
             className={`${styles['popup-current-application']} ${styles.count}`}
           >

--- a/src/components/GlobalNavigationBar/SideBar/SideBar.module.scss
+++ b/src/components/GlobalNavigationBar/SideBar/SideBar.module.scss
@@ -34,12 +34,6 @@
   min-height: var.$root_header_height_lg;
   padding: 0 24px;
 
-  & > p {
-    padding: 0 24px;
-
-    @include font.Style(2lg, 500);
-  }
-
   @include media.tablet {
     min-height: var.$root_header_height_md;
     padding: 0 16px;
@@ -47,6 +41,20 @@
 
   @include media.mobile {
     min-height: var.$root_header_height_sm;
+  }
+}
+
+.user {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  align-items: center;
+  padding: 0 24px;
+
+  @include font.Style(2lg, 500);
+
+  @include media.tablet {
+    padding: 0;
   }
 }
 

--- a/src/components/GlobalNavigationBar/SideBar/SideBar.tsx
+++ b/src/components/GlobalNavigationBar/SideBar/SideBar.tsx
@@ -1,3 +1,4 @@
+import Avatar from '@/components/Avatar/Avatar'
 import SignInOutButton from '@/components/Button/SignInOutButton/SignInOutButton'
 import XButton from '@/components/Button/XButton/XButton'
 import DefaultQueryProvider from '@/lib/queries/DefaultQueryProvider'
@@ -13,16 +14,20 @@ interface SideBarProps {
 
 export default function SideBar({ closeAction }: SideBarProps) {
   const user = useUserStore.getState().user
-  console.log('🚀 ~ SideBar ~ user:', user)
 
   return (
     <article className={styles.gnb}>
       <div className={styles.inner}>
         <section className={styles.head}>
-          <p>
-            {user &&
-              `반갑습니다! ${user.nickname} ${user.role === 'OWNER' ? '사장님' : '님'}`}
-          </p>
+          <div className={styles.user}>
+            {user && (
+              <>
+                <Avatar name={user.nickname} imageUrl={user.imageUrl} />
+                &nbsp;
+                {user.role === 'OWNER' ? '사장님' : '님'} 반갑습니다!
+              </>
+            )}
+          </div>
           <XButton onClick={closeAction} />
         </section>
         <section className={styles.body}>

--- a/src/components/Modal/MyApplication/MyApplication.tsx
+++ b/src/components/Modal/MyApplication/MyApplication.tsx
@@ -5,6 +5,7 @@ import {
   useMyApplicationQuery,
   useResumeFileQuery,
 } from '@/lib/queries/applicationDetailsQuery'
+import { decodeUTF8 } from '@/lib/utils/decodeUTF8'
 import { formatPhoneNumber } from '@/lib/utils/formatDate'
 import classNames from 'classnames'
 import Image from 'next/image'
@@ -37,10 +38,11 @@ export default function MyApplicationModal({
   )
 
   const application = isOwner ? ownerApplication : myApplication
+  const resumeName = decodeUTF8(application?.resumeName)
 
   const { refetch } = useResumeFileQuery(
     Number(application?.resumeId),
-    application?.resumeName,
+    resumeName,
   )
 
   const handleDownloadResumeClick = () => {
@@ -101,10 +103,9 @@ export default function MyApplicationModal({
               <div className={styles['content-description-resume']}>
                 <span className={styles['content-description-resume-title']}>
                   <span>
-                    {application?.resumeName &&
-                    application?.resumeName.length > 10
-                      ? `${application?.resumeName.slice(0, 10)}...`
-                      : application?.resumeName}
+                    {resumeName && resumeName.length > 20
+                      ? `${resumeName.slice(0, 20)}...`
+                      : resumeName}
                   </span>
                 </span>
                 <button

--- a/src/components/Modal/SelectStatus/SelectStatus.tsx
+++ b/src/components/Modal/SelectStatus/SelectStatus.tsx
@@ -3,6 +3,7 @@ import Toastify from '@/components/Toastify/Toastify'
 import { usePatchStatusMutation } from '@/lib/queries/applicationDetailsQuery'
 import { FORM_STATUS, FORM_STATUS_REVERSED } from '@/lib/types/formTypes'
 import handleError from '@/lib/utils/errorHandler'
+import { useQueryClient } from '@tanstack/react-query'
 import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react'
 import ReactModal from 'react-modal'
 import { toast } from 'react-toastify'
@@ -26,6 +27,7 @@ export default function SelectStatus({
   currentStatus,
   onStatusChange,
 }: SelectModalProps) {
+  const queryClient = useQueryClient()
   const { mutate: selectStatus } = usePatchStatusMutation()
   const [selectedStatus, setSelectedStatus] = useState(currentStatus)
 
@@ -42,10 +44,11 @@ export default function SelectStatus({
     selectStatus(
       { applicationId, status: englishStatus },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           onStatusChange(englishStatus)
           onRequestClose()
           toast.success('상태 변경 성공!')
+          await queryClient.invalidateQueries()
         },
         onError: () => {
           handleError(new Error('상태 수정 실패'))

--- a/src/hooks/auth/useSignOut.ts
+++ b/src/hooks/auth/useSignOut.ts
@@ -16,8 +16,8 @@ export default function useSignOut() {
     Cookies.remove('accessToken', { path: '/' })
     Cookies.remove('refreshToken', { path: '/' })
     queryClient.removeQueries({ queryKey: ['user'] }) // 쿼리 캐시에서 user 쿼리 제거
-    setUser(undefined)
     clearUserStorage()
+    setUser(undefined)
     router.push('/')
     if (typeof document !== 'undefined') return
     window.location.reload()

--- a/src/lib/utils/decodeUTF8.ts
+++ b/src/lib/utils/decodeUTF8.ts
@@ -1,0 +1,16 @@
+/**
+ * 파일명 디코더
+ */
+export const decodeUTF8 = (encodedStr: string) => {
+  try {
+    // 먼저 URL 디코딩
+    const percentDecoded = decodeURIComponent(encodedStr)
+    // 디코딩된 문자열을 다시 바이너리로 변환하여 UTF-8로 변환
+    return new TextDecoder().decode(
+      Uint8Array.from(percentDecoded, (c) => c.charCodeAt(0)),
+    )
+  } catch (e) {
+    console.error('디코딩 중 오류 발생:', e)
+    return encodedStr
+  }
+}


### PR DESCRIPTION
resolved: #250 

# 설명

- 지원하기 페이지
    - axios 인스턴스 변경
    - 작업취소 시 이전 페이지로 이동 (해당 알바폼의 상세페이지로)
    - 지원완료 후 상세페이지로 이동
    - 비밀번호 8자 이상 유효성 검사
    - 임시저장 기능 숨김처리
- 지원 상세보기
    - 파일명 디코딩 추가
    - 지원 상태 변경 후 캐시 리로드
- GNB
    - 사이드바의 사용자 닉네임 Avatar 컴포넌트 적용
- 알바폼 상세보기
    - 지원자 0명일 때 n명이 지원했다는 토스트 제거
- 알바목록, 내 알바폼
    - 폼 만들기 버튼 위치 수정